### PR TITLE
Fix #83 and LLNL/Silo#248

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,16 +23,9 @@ MFC is an exascale-ready fully-documented parallel simulation code for multi-com
 <p align="justify">
 MFC was first developed by the Colonius research group at Caltech.
 Now it is developed and maintained by the groups of Professors <a href="https://comp-physics.group">Spencer Bryngelson</a>, <a href="https://colonius.caltech.edu/">Tim Colonius</a>, and <a href="https://vivo.brown.edu/display/mrodri97">Mauro Rodriguez</a> (alphabetical).
-</p>
-
-| Name                 | Active             | Links                                                                                                  | Name                 | Active             | Links                                                                                                       | 
-| -------------------- | ------------------ | -------                                                                                                | -------------------- | ------------------ | -------                                                                                                     | 
-| **S. Bryngelson**    | :white_check_mark: | [Personal](https://comp-physics.group/)             \| [Research Group](https://comp-physics.group/)   | **J. Meng**          | :x:                | TBD                                                                                                         |
-| **T. Colonius**      | :white_check_mark: | [Personal](https://eas.caltech.edu/people/colonius) \| [Research Group](https://colonius.caltech.edu/) | **A. Radhakrishnan** | :white_check_mark: | [Personal](https://anandrdbz.github.io)             \| [Research Group](https://comp-physics.group/)        |
-| **V. Coralic**       | :x:                | TBD                                                                                                    | **M. Rodriguez**     | :white_check_mark: | [Personal](https://vivo.brown.edu/display/mrodri97) \| [Research Group](https://sites.brown.edu/rodriguez/) |
-| **H. Le Berre**      | :white_check_mark: | [Personal](https://henryleberre.github.io/)         \| [Research Group](https://comp-physics.group/)   | **K. Schmidmayer**   | :x:                | TBD                                                                                                         |
-| **K. Maeda**         | :x:                | TBD                                                                                                    | **J. Spratt**        | :white_check_mark: | TBD                                                                                                         |
-
+We try to maintain a list of current and past developers in the <a href="AUTHORS">AUTHORS</a> file!
+ </p>
+ 
 ## Publications
  
 ### Primary Paper
@@ -149,13 +142,13 @@ If you wish, you can override MFC's default build parameters in [mfc.user.yaml](
 
 ```console
 chmod +x ./mfc.sh
-./mfc.sh build -j 8 -cc release-cpu
+./mfc.sh --build -j 8 -cc release-cpu
 ```
 
 + Run MFC's tests to make sure it was correctly built and your environment is adequate
 
 ```console
-./mfc.sh test
+./mfc.sh --test
 ```
 
 Please refer to the <a href="#testing">Testing</a> section of this document for more information. 
@@ -193,9 +186,9 @@ for the flow variables via
  
 # Testing MFC
  
-To run MFC's test suite, simply run `./mfc.sh test`. It will generate and run test cases, to compare their output to that of previous runs from versions of MFC considered to be accurate. *golden files*, stored in the `tests/` directory contain this data, by aggregating `.dat` files generated when running MFC. A test is considered passing within a very small margin of error, to maintain a high level of stability and accuracy across versions of MFC.
+To run MFC's test suite, simply run `./mfc.sh --test`. It will generate and run test cases, to compare their output to that of previous runs from versions of MFC considered to be accurate. *golden files*, stored in the `tests/` directory contain this data, by aggregating `.dat` files generated when running MFC. A test is considered passing within a very small margin of error, to maintain a high level of stability and accuracy across versions of MFC.
  
-Adding a new test case is as simple as modifying [bootstrap/internal/test.py](bootstrap/internal/test.py), and selecting which parameters you want to vary from the base case. Then run `./mfc.sh test -g|--generate` to generate new golden files. Please make sure that these files are generated with accurate data.
+Adding a new test case is as simple as modifying [bootstrap/internal/test.py](bootstrap/internal/test.py), and selecting which parameters you want to vary from the base case. Then run `./mfc.sh --test -g|--generate` to generate new golden files. Please make sure that these files are generated with accurate data.
 
 If you want to only run certain tests, you can pass the argument `-o` (`--only`) along with the associated test ID or hash:
 - **Test ID:** It is the execution order of a test. The first test is `#1`, the next one is `#2`, and so on. If a test is added or removed, it could modify the test IDs of all tests executed after it.
@@ -203,7 +196,7 @@ If you want to only run certain tests, you can pass the argument `-o` (`--only`)
 
 An example of running targeted tests:
 ```console
-./mfc.sh test -o 7 5b486221
+./mfc.sh --test -o 7 5b486221
 ```
 
 # Development

--- a/bootstrap/mfc.dev.yaml
+++ b/bootstrap/mfc.dev.yaml
@@ -29,8 +29,8 @@ targets:
         git: https://github.com/HDFGroup/hdf5
         hash: 4aa40365623cf35643b262781f92578220c42bbb
     build:
-      - ./configure ${CONFIGURE_OPTIONS} ${COMPILERS} --enable-parallel --enable-deprecated-symbols --disable-sharedlib-rpath
-      - make ${MAKE_OPTIONS} ${COMPILER_FLAGS} ${COMPILERS}
+      - ./configure ${CONFIGURE_OPTIONS} ${COMPILERS} --enable-parallel --enable-deprecated-symbols --disable-sharedlib-rpath CFLAGS="-O2" CPPFLAGS="-O2" FFLAGS="-O2"
+      - make ${MAKE_OPTIONS} ${COMPILER_FLAGS} ${COMPILERS} CFLAGS="-O2" CPPFLAGS="-O2" FFLAGS="-O2"
       - make install prefix="${INSTALL_PATH}"
 
   - name: silo
@@ -47,7 +47,7 @@ targets:
         ./configure ${CONFIGURE_OPTIONS} --enable-pythonmodule --enable-optimization
         --disable-hzip --disable-fpzip --disable-silex
         --with-hdf5="${HDF5:INSTALL_PATH}/include","${HDF5:INSTALL_PATH}/lib"
-        ${COMPILERS} ${COMPILER_FLAGS} CFLAGS="-O0" CPPFLAGS="-O0" FFLAGS="-O0"
+        ${COMPILERS} ${COMPILER_FLAGS} CFLAGS="-O2" CPPFLAGS="-O2" FFLAGS="-O2"
       - make ${MAKE_OPTIONS}
       - make install prefix="${INSTALL_PATH}"
 

--- a/bootstrap/mfc.dev.yaml
+++ b/bootstrap/mfc.dev.yaml
@@ -1,10 +1,10 @@
 compiler_versions:
   - name:    GNU Fortran
-    is_used: exit $(expr $(${FORTRAN} --version | grep 'GNU Fortran' | wc -l) \=\= 0)
+    is_used: exit $(expr $(${FORTRAN} --version | grep 'GNU Fortran' | wc -l) \= 0)
     fetch:   ${FORTRAN} --version | grep 'GNU Fortran' | tr ' ' '\n' | tail -n 1
     minimum: 5.0.0
   - name:    NVHPC (NVFortran)
-    is_used: exit $(expr $(${FORTRAN} --version | grep 'nvfortran' | wc -l) \=\= 0)
+    is_used: exit $(expr $(${FORTRAN} --version | grep 'nvfortran' | wc -l) \= 0)
     fetch:   ${FORTRAN} --version | grep 'nvfortran' | tr ' ' '\n' | head -n 2 | tail -n 1
     minimum: 21.7.0
 

--- a/misc/load.sh
+++ b/misc/load.sh
@@ -3,11 +3,12 @@
 echo -e "\nPlease run this file with \"source\": \"source load.sh\"\n".
 
 echo "Which computer would you like to load submodules for?"
-echo " - Summit   (s)"
-echo " - Bridges2 (b)"
-echo " - Ascent   (a)"
-echo " - Wombat   (w)"
-echo -n "(s/b/a/w): "
+echo " - Summit     (s)"
+echo " - Bridges2   (b)"
+echo " - Ascent     (a)"
+echo " - Wombat     (w)"
+echo " - Richardson (r)"
+echo -n "(s/b/a/w/r): "
 read response
 
 if [ "$response" == "s" ]; then # For Summit
@@ -33,6 +34,12 @@ elif [ "$response" == "a" ]; then # For Ascent
     module load cuda/11.2.0
     module load nsight-compute
     module load nsight-systems
+    module list
+elif [ "$response" == "r" ]; then # Richardson
+    module purge
+    module load gcc/9.3.0
+    module load openmpi-2.0/gcc-9.3.0
+    module load python/3.7
     module list
 elif [ "$response" == "w" ]; then # For Wombat
     module purge


### PR DESCRIPTION
This Pull Request contains:
- A fix for #83 that caused macOS compiler checks to print an error
- A fix for the issue we described in LLNL/Silo#248 that made running `post_process` fail from within Silo
- Added modules for Richardson to `misc/load.sh`

Caveat: I will verify that running post_process gives me consistent results.