### PR TITLE
Making the bubbles/qbmm cases match exactly

### DIFF
--- a/src/simulation_code/m_weno.f90
+++ b/src/simulation_code/m_weno.f90
@@ -782,218 +782,406 @@ MODULE m_weno
             
             ! WENO3 ============================================================
             ELSEIF(weno_order == 3) THEN
-                
-                DO i = 1, v_size
-                    DO l = is3%beg, is3%end
-                        DO k = is2%beg, is2%end
-                            DO j = is1%beg, is1%end
-                                ! reconstruct from left side
 
-                                dvd( 0) = v_rs_wsL( 1)%vf(i)%sf(j,k,l) &
-                                        - v_rs_wsL( 0)%vf(i)%sf(j,k,l)
-                                dvd(-1) = v_rs_wsL( 0)%vf(i)%sf(j,k,l) &
-                                        - v_rs_wsL(-1)%vf(i)%sf(j,k,l)
-                                
-                                ! poly_coef_R(0,0,i+1) = (s_cb( i )-s_cb(i+1)) / &
-                                !                        (s_cb( i )-s_cb(i+2)) = 1/2
-                                ! poly_coef_R(1,0,i+1) = (s_cb( i )-s_cb(i+1)) / &
-                                !                        (s_cb(i-1)-s_cb(i+1)) = 1/2
-                                
-                                ! poly_coef_L(0,0,i+1) = -poly_coef_R(0,0,i+1) = -1/2
-                                ! poly_coef_L(1,0,i+1) = -poly_coef_R(1,0,i+1) = -1/2
- 
-                                ! so: poly_L[0] = v[j]-(1/2)(v[j+1]-v[j])
-                                ! so: poly_L[1] = v[j]-(1/2)(v[j]-v[j-1])
-                                poly_L(0) = v_rs_wsL(0)%vf(i)%sf(j,k,l) &
-                                          + poly_coef_L(0,0,j)*dvd( 0)
-                                poly_L(1) = v_rs_wsL(0)%vf(i)%sf(j,k,l) &
-                                          + poly_coef_L(1,0,j)*dvd(-1)
-                                
-                                ! beta_coef(0,0,i+1) = 4d0*(s_cb( i )-s_cb(i+1))**2d0 / &
-                                !                          (s_cb( i )-s_cb(i+2))**2d0
-                                ! beta_coef(1,0,i+1) = 4d0*(s_cb( i )-s_cb(i+1))**2d0 / &
-                                !                          (s_cb(i-1)-s_cb(i+1))**2d0
+                IF(char_decomp .AND. cd_vars /= dflt_int) THEN
+                    DO i = 1, v_size
+                        DO l = is3%beg, is3%end
+                            DO k = is2%beg, is2%end
+                                DO j = is1%beg, is1%end
+                                    ! reconstruct from left side
 
-                                ! so for uniform mesh: beta_coef(0,0,j) = 4*((-dx)**2) / (-2dx)**2 = 1
-                                ! so for uniform mesh: beta_coef(1,0,j) = 4*((-dx)**2) / (-2dx)**2 = 1
+                                    dvd( 0) = v_rs_wsL( 1)%vf(i)%sf(j,k,l) &
+                                            - v_rs_wsL( 0)%vf(i)%sf(j,k,l)
+                                    dvd(-1) = v_rs_wsL( 0)%vf(i)%sf(j,k,l) &
+                                            - v_rs_wsL(-1)%vf(i)%sf(j,k,l)
+                                    
+                                    ! poly_coef_R(0,0,i+1) = (s_cb( i )-s_cb(i+1)) / &
+                                    !                        (s_cb( i )-s_cb(i+2)) = 1/2
+                                    ! poly_coef_R(1,0,i+1) = (s_cb( i )-s_cb(i+1)) / &
+                                    !                        (s_cb(i-1)-s_cb(i+1)) = 1/2
+                                    
+                                    ! poly_coef_L(0,0,i+1) = -poly_coef_R(0,0,i+1) = -1/2
+                                    ! poly_coef_L(1,0,i+1) = -poly_coef_R(1,0,i+1) = -1/2
+     
+                                    ! so: poly_L[0] = v[j]-(1/2)(v[j+1]-v[j])
+                                    ! so: poly_L[1] = v[j]-(1/2)(v[j]-v[j-1])
+                                    poly_L(0) = v_rs_wsL(0)%vf(i)%sf(j,k,l) &
+                                              + poly_coef_L(0,0,j)*dvd( 0)
+                                    poly_L(1) = v_rs_wsL(0)%vf(i)%sf(j,k,l) &
+                                              + poly_coef_L(1,0,j)*dvd(-1)
+                                    
+                                    ! beta_coef(0,0,i+1) = 4d0*(s_cb( i )-s_cb(i+1))**2d0 / &
+                                    !                          (s_cb( i )-s_cb(i+2))**2d0
+                                    ! beta_coef(1,0,i+1) = 4d0*(s_cb( i )-s_cb(i+1))**2d0 / &
+                                    !                          (s_cb(i-1)-s_cb(i+1))**2d0
 
-                                ! so: beta[0] = (v[j+1]-v[j])**2 + weno_eps
-                                ! so: beta[1] = (v[j]-v[j-1])**2 + weno_eps
-                                beta(0) = beta_coef(0,0,j)*dvd( 0)*dvd( 0) &
-                                        + weno_eps
-                                beta(1) = beta_coef(1,0,j)*dvd(-1)*dvd(-1) &
-                                        + weno_eps
-                                
-                                ! d_L(0,i+1) = (s_cb(i-1)-s_cb( i )) / &
-                                !              (s_cb(i-1)-s_cb(i+2))
-                                !            = (-dx)/(-3dx) = 1/3
-                                ! d_L(1,i+1) = 1d0 - d_L(0,i+1)
-                                !            = 1-1/3 = 2/3
+                                    ! so for uniform mesh: beta_coef(0,0,j) = 4*((-dx)**2) / (-2dx)**2 = 1
+                                    ! so for uniform mesh: beta_coef(1,0,j) = 4*((-dx)**2) / (-2dx)**2 = 1
 
-                                ! so: alpha_L[0] = (1/3)/( (v[j+1]-v[j])^2 + weno_eps )^2
-                                ! so: alpha_L[1] = (2/3)/( (v[j]-v[j-1])^2 + weno_eps )^2
-                                alpha_L = d_L(:,j)/(beta*beta)
-                                
-                                ! so: omega_L[0] = (1/3)/( (v[j+1]-v[j])^2 + weno_eps )^2
-                                !                  --------------------------------------
-                                ! (2/3)/( (v[j]-v[j-1])^2 + weno_eps )^2 + (1/3)/( (v[j+1]-v[j])^2 + weno_eps )^2
+                                    ! so: beta[0] = (v[j+1]-v[j])**2 + weno_eps
+                                    ! so: beta[1] = (v[j]-v[j-1])**2 + weno_eps
+                                    beta(0) = beta_coef(0,0,j)*dvd( 0)*dvd( 0) &
+                                            + weno_eps
+                                    beta(1) = beta_coef(1,0,j)*dvd(-1)*dvd(-1) &
+                                            + weno_eps
+                                    
+                                    ! d_L(0,i+1) = (s_cb(i-1)-s_cb( i )) / &
+                                    !              (s_cb(i-1)-s_cb(i+2))
+                                    !            = (-dx)/(-3dx) = 1/3
+                                    ! d_L(1,i+1) = 1d0 - d_L(0,i+1)
+                                    !            = 1-1/3 = 2/3
 
-                                ! so: omega_L[1] = (2/3)/( (v[j]-v[j-1])^2 + weno_eps )^2
-                                !                  --------------------------------------
-                                ! (2/3)/( (v[j]-v[j-1])^2 + weno_eps )^2 + (1/3)/( (v[j+1]-v[j])^2 + weno_eps )^2
-                                omega_L = alpha_L/SUM(alpha_L)
+                                    ! so: alpha_L[0] = (1/3)/( (v[j+1]-v[j])^2 + weno_eps )^2
+                                    ! so: alpha_L[1] = (2/3)/( (v[j]-v[j-1])^2 + weno_eps )^2
+                                    alpha_L = d_L(:,j)/(beta*beta)
+                                    
+                                    ! so: omega_L[0] = (1/3)/( (v[j+1]-v[j])^2 + weno_eps )^2
+                                    !                  --------------------------------------
+                                    ! (2/3)/( (v[j]-v[j-1])^2 + weno_eps )^2 + (1/3)/( (v[j+1]-v[j])^2 + weno_eps )^2
+
+                                    ! so: omega_L[1] = (2/3)/( (v[j]-v[j-1])^2 + weno_eps )^2
+                                    !                  --------------------------------------
+                                    ! (2/3)/( (v[j]-v[j-1])^2 + weno_eps )^2 + (1/3)/( (v[j+1]-v[j])^2 + weno_eps )^2
+                                    omega_L = alpha_L/SUM(alpha_L)
 
 
-                                ! reconstruct from right side
-                                dvd( 0) = v_rs_wsR( 1)%vf(i)%sf(j,k,l) &
-                                        - v_rs_wsR( 0)%vf(i)%sf(j,k,l)
-                                dvd(-1) = v_rs_wsR( 0)%vf(i)%sf(j,k,l) &
-                                        - v_rs_wsR(-1)%vf(i)%sf(j,k,l)
+                                    ! reconstruct from right side
+                                    dvd( 0) = v_rs_wsR( 1)%vf(i)%sf(j,k,l) &
+                                            - v_rs_wsR( 0)%vf(i)%sf(j,k,l)
+                                    dvd(-1) = v_rs_wsR( 0)%vf(i)%sf(j,k,l) &
+                                            - v_rs_wsR(-1)%vf(i)%sf(j,k,l)
 
-                                ! poly_coef_R(0,0,j) = -dx/(-2 dx) = 1/2
-                                ! poly_coef_R(1,0,j) = -dx/(-2 dx) = 1/2
+                                    ! poly_coef_R(0,0,j) = -dx/(-2 dx) = 1/2
+                                    ! poly_coef_R(1,0,j) = -dx/(-2 dx) = 1/2
 
-                                poly_R(0) = v_rs_wsR(0)%vf(i)%sf(j,k,l) &
-                                          + poly_coef_R(0,0,j)*dvd( 0)
-                                poly_R(1) = v_rs_wsR(0)%vf(i)%sf(j,k,l) &
-                                          + poly_coef_R(1,0,j)*dvd(-1)
-                                
-                                beta(0) = beta_coef(0,0,j)*dvd( 0)*dvd( 0) &
-                                        + weno_eps
-                                beta(1) = beta_coef(1,0,j)*dvd(-1)*dvd(-1) &
-                                        + weno_eps
-                                
+                                    poly_R(0) = v_rs_wsR(0)%vf(i)%sf(j,k,l) &
+                                              + poly_coef_R(0,0,j)*dvd( 0)
+                                    poly_R(1) = v_rs_wsR(0)%vf(i)%sf(j,k,l) &
+                                              + poly_coef_R(1,0,j)*dvd(-1)
+                                    
+                                    
 
-                                ! d_R(0,i+1) = (s_cb(i-1)-s_cb(i+1)) / &
-                                !              (s_cb(i-1)-s_cb(i+2))
-                                !            = 2/3
-                                ! d_R(1,i+1) = 1d0 - d_R(0,i+1)
-                                !            = 1-2/3 = 1/3
+                                    ! d_R(0,i+1) = (s_cb(i-1)-s_cb(i+1)) / &
+                                    !              (s_cb(i-1)-s_cb(i+2))
+                                    !            = 2/3
+                                    ! d_R(1,i+1) = 1d0 - d_R(0,i+1)
+                                    !            = 1-2/3 = 1/3
 
-                                alpha_R = d_R(:,j)/(beta*beta)
-                                
-                                omega_R = alpha_R/SUM(alpha_R)
-                                
-                                IF(mapped_weno) THEN
-                                    CALL s_map_nonlinear_weights( d_L(:,j), &
-                                                                   alpha_L, &
-                                                                   omega_L  )
-                                    CALL s_map_nonlinear_weights( d_R(:,j), &
-                                                                   alpha_R, &
-                                                                   omega_R  )
-                                END IF
-                                
-                                vL_rs_vf(i)%sf(j,k,l) = SUM(omega_L*poly_L)
-                                vR_rs_vf(i)%sf(j,k,l) = SUM(omega_R*poly_R)
-                                
+                                    beta(0) = beta_coef(0,0,j)*dvd( 0)*dvd( 0) &
+                                            + weno_eps
+                                    beta(1) = beta_coef(1,0,j)*dvd(-1)*dvd(-1) &
+                                            + weno_eps
+
+                                    alpha_R = d_R(:,j)/(beta*beta)
+                                    
+                                    omega_R = alpha_R/SUM(alpha_R)
+                                    
+                                    IF(mapped_weno) THEN
+                                        CALL s_map_nonlinear_weights( d_L(:,j), &
+                                                                       alpha_L, &
+                                                                       omega_L  )
+                                        CALL s_map_nonlinear_weights( d_R(:,j), &
+                                                                       alpha_R, &
+                                                                       omega_R  )
+                                    END IF
+                                    
+                                    vL_rs_vf(i)%sf(j,k,l) = SUM(omega_L*poly_L)
+                                    vR_rs_vf(i)%sf(j,k,l) = SUM(omega_R*poly_R)
+                                    
+                                END DO
                             END DO
                         END DO
                     END DO
-                END DO
+                ELSE              
+                    DO i = 1, v_size
+                        DO l = is3%beg, is3%end
+                            DO k = is2%beg, is2%end
+                                DO j = is1%beg, is1%end
+                                    ! reconstruct from left side
+
+                                    dvd( 0) = v_rs_wsL( 1)%vf(i)%sf(j,k,l) &
+                                            - v_rs_wsL( 0)%vf(i)%sf(j,k,l)
+                                    dvd(-1) = v_rs_wsL( 0)%vf(i)%sf(j,k,l) &
+                                            - v_rs_wsL(-1)%vf(i)%sf(j,k,l)
+                                    
+                                    ! poly_coef_R(0,0,i+1) = (s_cb( i )-s_cb(i+1)) / &
+                                    !                        (s_cb( i )-s_cb(i+2)) = 1/2
+                                    ! poly_coef_R(1,0,i+1) = (s_cb( i )-s_cb(i+1)) / &
+                                    !                        (s_cb(i-1)-s_cb(i+1)) = 1/2
+                                    
+                                    ! poly_coef_L(0,0,i+1) = -poly_coef_R(0,0,i+1) = -1/2
+                                    ! poly_coef_L(1,0,i+1) = -poly_coef_R(1,0,i+1) = -1/2
+     
+                                    ! so: poly_L[0] = v[j]-(1/2)(v[j+1]-v[j])
+                                    ! so: poly_L[1] = v[j]-(1/2)(v[j]-v[j-1])
+                                    poly_L(0) = v_rs_wsL(0)%vf(i)%sf(j,k,l) &
+                                              + poly_coef_L(0,0,j)*dvd( 0)
+                                    poly_L(1) = v_rs_wsL(0)%vf(i)%sf(j,k,l) &
+                                              + poly_coef_L(1,0,j)*dvd(-1)
+                                    
+                                    ! beta_coef(0,0,i+1) = 4d0*(s_cb( i )-s_cb(i+1))**2d0 / &
+                                    !                          (s_cb( i )-s_cb(i+2))**2d0
+                                    ! beta_coef(1,0,i+1) = 4d0*(s_cb( i )-s_cb(i+1))**2d0 / &
+                                    !                          (s_cb(i-1)-s_cb(i+1))**2d0
+
+                                    ! so for uniform mesh: beta_coef(0,0,j) = 4*((-dx)**2) / (-2dx)**2 = 1
+                                    ! so for uniform mesh: beta_coef(1,0,j) = 4*((-dx)**2) / (-2dx)**2 = 1
+
+                                    ! so: beta[0] = (v[j+1]-v[j])**2 + weno_eps
+                                    ! so: beta[1] = (v[j]-v[j-1])**2 + weno_eps
+                                    beta(0) = beta_coef(0,0,j)*dvd( 0)*dvd( 0) &
+                                            + weno_eps
+                                    beta(1) = beta_coef(1,0,j)*dvd(-1)*dvd(-1) &
+                                            + weno_eps
+                                    
+                                    ! d_L(0,i+1) = (s_cb(i-1)-s_cb( i )) / &
+                                    !              (s_cb(i-1)-s_cb(i+2))
+                                    !            = (-dx)/(-3dx) = 1/3
+                                    ! d_L(1,i+1) = 1d0 - d_L(0,i+1)
+                                    !            = 1-1/3 = 2/3
+
+                                    ! so: alpha_L[0] = (1/3)/( (v[j+1]-v[j])^2 + weno_eps )^2
+                                    ! so: alpha_L[1] = (2/3)/( (v[j]-v[j-1])^2 + weno_eps )^2
+                                    alpha_L = d_L(:,j)/(beta*beta)
+                                    
+                                    ! so: omega_L[0] = (1/3)/( (v[j+1]-v[j])^2 + weno_eps )^2
+                                    !                  --------------------------------------
+                                    ! (2/3)/( (v[j]-v[j-1])^2 + weno_eps )^2 + (1/3)/( (v[j+1]-v[j])^2 + weno_eps )^2
+
+                                    ! so: omega_L[1] = (2/3)/( (v[j]-v[j-1])^2 + weno_eps )^2
+                                    !                  --------------------------------------
+                                    ! (2/3)/( (v[j]-v[j-1])^2 + weno_eps )^2 + (1/3)/( (v[j+1]-v[j])^2 + weno_eps )^2
+                                    omega_L = alpha_L/SUM(alpha_L)
+
+
+                                    ! reconstruct from right side
+
+                                    ! poly_coef_R(0,0,j) = -dx/(-2 dx) = 1/2
+                                    ! poly_coef_R(1,0,j) = -dx/(-2 dx) = 1/2
+
+                                    poly_R(0) = v_rs_wsL(0)%vf(i)%sf(j,k,l) &
+                                              + poly_coef_R(0,0,j)*dvd( 0)
+                                    poly_R(1) = v_rs_wsL(0)%vf(i)%sf(j,k,l) &
+                                              + poly_coef_R(1,0,j)*dvd(-1)
+                                    
+                                    
+
+                                    ! d_R(0,i+1) = (s_cb(i-1)-s_cb(i+1)) / &
+                                    !              (s_cb(i-1)-s_cb(i+2))
+                                    !            = 2/3
+                                    ! d_R(1,i+1) = 1d0 - d_R(0,i+1)
+                                    !            = 1-2/3 = 1/3
+
+                                    alpha_R = d_R(:,j)/(beta*beta)
+                                    
+                                    omega_R = alpha_R/SUM(alpha_R)
+                                    
+                                    IF(mapped_weno) THEN
+                                        CALL s_map_nonlinear_weights( d_L(:,j), &
+                                                                       alpha_L, &
+                                                                       omega_L  )
+                                        CALL s_map_nonlinear_weights( d_R(:,j), &
+                                                                       alpha_R, &
+                                                                       omega_R  )
+                                    END IF
+                                    
+                                    vL_rs_vf(i)%sf(j,k,l) = SUM(omega_L*poly_L)
+                                    vR_rs_vf(i)%sf(j,k,l) = SUM(omega_R*poly_R)
+                                    
+                                END DO
+                            END DO
+                        END DO
+                    END DO
+                END IF
                 
             ! END: WENO3 =======================================================
             
             
             ! WENO5 ============================================================
             ELSE
-                
-                DO i = 1, v_size
-                    DO l = is3%beg, is3%end
-                        DO k = is2%beg, is2%end
-                            DO j = is1%beg, is1%end
-                                
-                                dvd( 1) = v_rs_wsL( 2)%vf(i)%sf(j,k,l) &
-                                        - v_rs_wsL( 1)%vf(i)%sf(j,k,l)
-                                dvd( 0) = v_rs_wsL( 1)%vf(i)%sf(j,k,l) &
-                                        - v_rs_wsL( 0)%vf(i)%sf(j,k,l)
-                                dvd(-1) = v_rs_wsL( 0)%vf(i)%sf(j,k,l) &
-                                        - v_rs_wsL(-1)%vf(i)%sf(j,k,l)
-                                dvd(-2) = v_rs_wsL(-1)%vf(i)%sf(j,k,l) &
-                                        - v_rs_wsL(-2)%vf(i)%sf(j,k,l)
-                                
-                                poly_L(0) = v_rs_wsL(0)%vf(i)%sf(j,k,l) &
-                                          + poly_coef_L(0,0,j)*dvd( 1)  &
-                                          + poly_coef_L(0,1,j)*dvd( 0)
-                                poly_L(1) = v_rs_wsL(0)%vf(i)%sf(j,k,l) &
-                                          + poly_coef_L(1,0,j)*dvd( 0)  &
-                                          + poly_coef_L(1,1,j)*dvd(-1)
-                                poly_L(2) = v_rs_wsL(0)%vf(i)%sf(j,k,l) &
-                                          + poly_coef_L(2,0,j)*dvd(-1)  &
-                                          + poly_coef_L(2,1,j)*dvd(-2)
-                                
-                                beta(0) = beta_coef(0,0,j)*dvd( 1)*dvd( 1) &
-                                        + beta_coef(0,1,j)*dvd( 1)*dvd( 0) &
-                                        + beta_coef(0,2,j)*dvd( 0)*dvd( 0) &
-                                        + weno_eps
-                                beta(1) = beta_coef(1,0,j)*dvd( 0)*dvd( 0) &
-                                        + beta_coef(1,1,j)*dvd( 0)*dvd(-1) &
-                                        + beta_coef(1,2,j)*dvd(-1)*dvd(-1) &
-                                        + weno_eps
-                                beta(2) = beta_coef(2,0,j)*dvd(-1)*dvd(-1) &
-                                        + beta_coef(2,1,j)*dvd(-1)*dvd(-2) &
-                                        + beta_coef(2,2,j)*dvd(-2)*dvd(-2) &
-                                        + weno_eps
-                                
-                                alpha_L = d_L(:,j)/(beta*beta)
-                                
-                                omega_L = alpha_L/SUM(alpha_L)
-                                
-                                dvd( 1) = v_rs_wsR( 2)%vf(i)%sf(j,k,l) &
-                                        - v_rs_wsR( 1)%vf(i)%sf(j,k,l)
-                                dvd( 0) = v_rs_wsR( 1)%vf(i)%sf(j,k,l) &
-                                        - v_rs_wsR( 0)%vf(i)%sf(j,k,l)
-                                dvd(-1) = v_rs_wsR( 0)%vf(i)%sf(j,k,l) &
-                                        - v_rs_wsR(-1)%vf(i)%sf(j,k,l)
-                                dvd(-2) = v_rs_wsR(-1)%vf(i)%sf(j,k,l) &
-                                        - v_rs_wsR(-2)%vf(i)%sf(j,k,l)
-                                
-                                poly_R(0) = v_rs_wsR(0)%vf(i)%sf(j,k,l) &
-                                          + poly_coef_R(0,0,j)*dvd( 1)  &
-                                          + poly_coef_R(0,1,j)*dvd( 0)
-                                poly_R(1) = v_rs_wsR(0)%vf(i)%sf(j,k,l) &
-                                          + poly_coef_R(1,0,j)*dvd( 0)  &
-                                          + poly_coef_R(1,1,j)*dvd(-1)
-                                poly_R(2) = v_rs_wsR(0)%vf(i)%sf(j,k,l) &
-                                          + poly_coef_R(2,0,j)*dvd(-1)  &
-                                          + poly_coef_R(2,1,j)*dvd(-2)
-                                
-                                beta(0) = beta_coef(0,0,j)*dvd( 1)*dvd( 1) &
-                                        + beta_coef(0,1,j)*dvd( 1)*dvd( 0) &
-                                        + beta_coef(0,2,j)*dvd( 0)*dvd( 0) &
-                                        + weno_eps
-                                beta(1) = beta_coef(1,0,j)*dvd( 0)*dvd( 0) &
-                                        + beta_coef(1,1,j)*dvd( 0)*dvd(-1) &
-                                        + beta_coef(1,2,j)*dvd(-1)*dvd(-1) &
-                                        + weno_eps
-                                beta(2) = beta_coef(2,0,j)*dvd(-1)*dvd(-1) &
-                                        + beta_coef(2,1,j)*dvd(-1)*dvd(-2) &
-                                        + beta_coef(2,2,j)*dvd(-2)*dvd(-2) &
-                                        + weno_eps
-                                
-                                alpha_R = d_R(:,j)/(beta*beta)
-                                
-                                omega_R = alpha_R/SUM(alpha_R)
-                                
-                                IF(mapped_weno) THEN
-                                    CALL s_map_nonlinear_weights( d_L(:,j), &
-                                                                   alpha_L, &
-                                                                   omega_L  )
-                                    CALL s_map_nonlinear_weights( d_R(:,j), &
-                                                                   alpha_R, &
-                                                                   omega_R  )
-                                END IF
-                                
-                                vL_rs_vf(i)%sf(j,k,l) = SUM(omega_L*poly_L)
-                                vR_rs_vf(i)%sf(j,k,l) = SUM(omega_R*poly_R)
-                                
-                                IF(mp_weno .AND. weno_loc == 1) THEN
-                                    CALL s_preserve_monotonicity(i,j,k,l)
-                                END IF
-                                
+                IF(char_decomp .AND. cd_vars /= dflt_int) THEN
+                    DO i = 1, v_size
+                        DO l = is3%beg, is3%end
+                            DO k = is2%beg, is2%end
+                                DO j = is1%beg, is1%end
+                                    
+                                    dvd( 1) = v_rs_wsL( 2)%vf(i)%sf(j,k,l) &
+                                            - v_rs_wsL( 1)%vf(i)%sf(j,k,l)
+                                    dvd( 0) = v_rs_wsL( 1)%vf(i)%sf(j,k,l) &
+                                            - v_rs_wsL( 0)%vf(i)%sf(j,k,l)
+                                    dvd(-1) = v_rs_wsL( 0)%vf(i)%sf(j,k,l) &
+                                            - v_rs_wsL(-1)%vf(i)%sf(j,k,l)
+                                    dvd(-2) = v_rs_wsL(-1)%vf(i)%sf(j,k,l) &
+                                            - v_rs_wsL(-2)%vf(i)%sf(j,k,l)
+                                    
+                                    poly_L(0) = v_rs_wsL(0)%vf(i)%sf(j,k,l) &
+                                              + poly_coef_L(0,0,j)*dvd( 1)  &
+                                              + poly_coef_L(0,1,j)*dvd( 0)
+                                    poly_L(1) = v_rs_wsL(0)%vf(i)%sf(j,k,l) &
+                                              + poly_coef_L(1,0,j)*dvd( 0)  &
+                                              + poly_coef_L(1,1,j)*dvd(-1)
+                                    poly_L(2) = v_rs_wsL(0)%vf(i)%sf(j,k,l) &
+                                              + poly_coef_L(2,0,j)*dvd(-1)  &
+                                              + poly_coef_L(2,1,j)*dvd(-2)
+                                    
+                                    beta(0) = beta_coef(0,0,j)*dvd( 1)*dvd( 1) &
+                                            + beta_coef(0,1,j)*dvd( 1)*dvd( 0) &
+                                            + beta_coef(0,2,j)*dvd( 0)*dvd( 0) &
+                                            + weno_eps
+                                    beta(1) = beta_coef(1,0,j)*dvd( 0)*dvd( 0) &
+                                            + beta_coef(1,1,j)*dvd( 0)*dvd(-1) &
+                                            + beta_coef(1,2,j)*dvd(-1)*dvd(-1) &
+                                            + weno_eps
+                                    beta(2) = beta_coef(2,0,j)*dvd(-1)*dvd(-1) &
+                                            + beta_coef(2,1,j)*dvd(-1)*dvd(-2) &
+                                            + beta_coef(2,2,j)*dvd(-2)*dvd(-2) &
+                                            + weno_eps
+                                    
+                                    alpha_L = d_L(:,j)/(beta*beta)
+                                    
+                                    omega_L = alpha_L/SUM(alpha_L)
+
+                                    dvd( 1) = v_rs_wsR( 2)%vf(i)%sf(j,k,l) &
+                                            - v_rs_wsR( 1)%vf(i)%sf(j,k,l)
+                                    dvd( 0) = v_rs_wsR( 1)%vf(i)%sf(j,k,l) &
+                                            - v_rs_wsR( 0)%vf(i)%sf(j,k,l)
+                                    dvd(-1) = v_rs_wsR( 0)%vf(i)%sf(j,k,l) &
+                                            - v_rs_wsR(-1)%vf(i)%sf(j,k,l)
+                                    dvd(-2) = v_rs_wsR(-1)%vf(i)%sf(j,k,l) &
+                                            - v_rs_wsR(-2)%vf(i)%sf(j,k,l)
+
+                                   
+                                    
+                                    poly_R(0) = v_rs_wsR(0)%vf(i)%sf(j,k,l) &
+                                              + poly_coef_R(0,0,j)*dvd( 1)  &
+                                              + poly_coef_R(0,1,j)*dvd( 0)
+                                    poly_R(1) = v_rs_wsR(0)%vf(i)%sf(j,k,l) &
+                                              + poly_coef_R(1,0,j)*dvd( 0)  &
+                                              + poly_coef_R(1,1,j)*dvd(-1)
+                                    poly_R(2) = v_rs_wsR(0)%vf(i)%sf(j,k,l) &
+                                              + poly_coef_R(2,0,j)*dvd(-1)  &
+                                              + poly_coef_R(2,1,j)*dvd(-2)
+                                    
+                                    beta(0) = beta_coef(0,0,j)*dvd( 1)*dvd( 1) &
+                                            + beta_coef(0,1,j)*dvd( 1)*dvd( 0) &
+                                            + beta_coef(0,2,j)*dvd( 0)*dvd( 0) &
+                                            + weno_eps
+                                    beta(1) = beta_coef(1,0,j)*dvd( 0)*dvd( 0) &
+                                            + beta_coef(1,1,j)*dvd( 0)*dvd(-1) &
+                                            + beta_coef(1,2,j)*dvd(-1)*dvd(-1) &
+                                            + weno_eps
+                                    beta(2) = beta_coef(2,0,j)*dvd(-1)*dvd(-1) &
+                                            + beta_coef(2,1,j)*dvd(-1)*dvd(-2) &
+                                            + beta_coef(2,2,j)*dvd(-2)*dvd(-2) &
+                                            + weno_eps
+
+                                    
+                                    alpha_R = d_R(:,j)/(beta*beta)
+                                    
+                                    omega_R = alpha_R/SUM(alpha_R)
+                                    
+                                    IF(mapped_weno) THEN
+                                        CALL s_map_nonlinear_weights( d_L(:,j), &
+                                                                       alpha_L, &
+                                                                       omega_L  )
+                                        CALL s_map_nonlinear_weights( d_R(:,j), &
+                                                                       alpha_R, &
+                                                                       omega_R  )
+                                    END IF
+                                    
+                                    vL_rs_vf(i)%sf(j,k,l) = SUM(omega_L*poly_L)
+                                    vR_rs_vf(i)%sf(j,k,l) = SUM(omega_R*poly_R)
+                                    
+                                    IF(mp_weno .AND. weno_loc == 1) THEN
+                                        CALL s_preserve_monotonicity(i,j,k,l)
+                                    END IF
+                                    
+                                END DO
                             END DO
                         END DO
                     END DO
-                END DO
+                ELSE
+                    DO i = 1, v_size
+                        DO l = is3%beg, is3%end
+                            DO k = is2%beg, is2%end
+                                DO j = is1%beg, is1%end
+                                    
+                                    dvd( 1) = v_rs_wsL( 2)%vf(i)%sf(j,k,l) &
+                                            - v_rs_wsL( 1)%vf(i)%sf(j,k,l)
+                                    dvd( 0) = v_rs_wsL( 1)%vf(i)%sf(j,k,l) &
+                                            - v_rs_wsL( 0)%vf(i)%sf(j,k,l)
+                                    dvd(-1) = v_rs_wsL( 0)%vf(i)%sf(j,k,l) &
+                                            - v_rs_wsL(-1)%vf(i)%sf(j,k,l)
+                                    dvd(-2) = v_rs_wsL(-1)%vf(i)%sf(j,k,l) &
+                                            - v_rs_wsL(-2)%vf(i)%sf(j,k,l)
+                                    
+                                    poly_L(0) = v_rs_wsL(0)%vf(i)%sf(j,k,l) &
+                                              + poly_coef_L(0,0,j)*dvd( 1)  &
+                                              + poly_coef_L(0,1,j)*dvd( 0)
+                                    poly_L(1) = v_rs_wsL(0)%vf(i)%sf(j,k,l) &
+                                              + poly_coef_L(1,0,j)*dvd( 0)  &
+                                              + poly_coef_L(1,1,j)*dvd(-1)
+                                    poly_L(2) = v_rs_wsL(0)%vf(i)%sf(j,k,l) &
+                                              + poly_coef_L(2,0,j)*dvd(-1)  &
+                                              + poly_coef_L(2,1,j)*dvd(-2)
+                                    
+                                    beta(0) = beta_coef(0,0,j)*dvd( 1)*dvd( 1) &
+                                            + beta_coef(0,1,j)*dvd( 1)*dvd( 0) &
+                                            + beta_coef(0,2,j)*dvd( 0)*dvd( 0) &
+                                            + weno_eps
+                                    beta(1) = beta_coef(1,0,j)*dvd( 0)*dvd( 0) &
+                                            + beta_coef(1,1,j)*dvd( 0)*dvd(-1) &
+                                            + beta_coef(1,2,j)*dvd(-1)*dvd(-1) &
+                                            + weno_eps
+                                    beta(2) = beta_coef(2,0,j)*dvd(-1)*dvd(-1) &
+                                            + beta_coef(2,1,j)*dvd(-1)*dvd(-2) &
+                                            + beta_coef(2,2,j)*dvd(-2)*dvd(-2) &
+                                            + weno_eps
+                                    
+                                    alpha_L = d_L(:,j)/(beta*beta)
+                                    
+                                    omega_L = alpha_L/SUM(alpha_L)
+
+
+                                   
+                                    
+                                    poly_R(0) = v_rs_wsL(0)%vf(i)%sf(j,k,l) &
+                                              + poly_coef_R(0,0,j)*dvd( 1)  &
+                                              + poly_coef_R(0,1,j)*dvd( 0)
+                                    poly_R(1) = v_rs_wsL(0)%vf(i)%sf(j,k,l) &
+                                              + poly_coef_R(1,0,j)*dvd( 0)  &
+                                              + poly_coef_R(1,1,j)*dvd(-1)
+                                    poly_R(2) = v_rs_wsL(0)%vf(i)%sf(j,k,l) &
+                                              + poly_coef_R(2,0,j)*dvd(-1)  &
+                                              + poly_coef_R(2,1,j)*dvd(-2)
+                                    
+
+                                    
+                                    alpha_R = d_R(:,j)/(beta*beta)
+                                    
+                                    omega_R = alpha_R/SUM(alpha_R)
+                                    
+                                    IF(mapped_weno) THEN
+                                        CALL s_map_nonlinear_weights( d_L(:,j), &
+                                                                       alpha_L, &
+                                                                       omega_L  )
+                                        CALL s_map_nonlinear_weights( d_R(:,j), &
+                                                                       alpha_R, &
+                                                                       omega_R  )
+                                    END IF
+                                    
+                                    vL_rs_vf(i)%sf(j,k,l) = SUM(omega_L*poly_L)
+                                    vR_rs_vf(i)%sf(j,k,l) = SUM(omega_R*poly_R)
+                                    
+                                    IF(mp_weno .AND. weno_loc == 1) THEN
+                                        CALL s_preserve_monotonicity(i,j,k,l)
+                                    END IF
+                                    
+                                END DO
+                            END DO
+                        END DO
+                    END DO
+                END IF
                 
             END IF
             ! END: WENO5 =======================================================


### PR DESCRIPTION
This completely prevents floating point errors in bubbles/qbmm case irrespective of weno_eps