### PR TITLE
Bug in compute viscous stress tensor

### DIFF
--- a/src/simulation_code/m_rhs.f90
+++ b/src/simulation_code/m_rhs.f90
@@ -3328,6 +3328,10 @@ MODULE m_rhs
                     DO k = -1, 1
                         DO j = ix%beg, ix%end
 
+                            CALL s_convert_to_mixture_variables(    q_prim_vf, rho_visc, &
+                                                                gamma_visc, pi_inf_visc, &
+                                                                Re_visc, We_visc, j,k,l  )
+
                             tau_Re(2,2) = grad_z_vf(3)%sf(j,k,l) / y_cc(k) / &
                                           Re_visc(2)
 


### PR DESCRIPTION
Re_visc is used but not defined in this particular case when Re_size(2) > 0 (pretty sure this is a bug as the function is called in all other cases)