### PR TITLE
Bug fixes & macOS CI @ master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
         - os:    ubuntu-latest
           nvhpc: 22.3
           cuda:  11.6
+        - os:    macos-latest
+          gcc:   11
     runs-on: ${{ matrix.os }}
     steps:
       - name: Clone MFC

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, GPU ]
     paths:
       - '**.f90'
       - '**.fpp'
@@ -15,34 +15,97 @@ on:
       - 'makefile'
 
   pull_request:
-    branches: [ master ]
+    branches: [ master, GPU ]
 
   workflow_dispatch:
 
 jobs:
-  Ubuntu:
-    runs-on: ubuntu-latest
-
+  CI:
+    strategy:
+      matrix:
+        include:
+        - os:    ubuntu-latest
+          nvhpc: 22.3
+          cuda:  11.6
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Clone MFC
         uses: actions/checkout@v2
 
-      - name: Install Dependencies (via Aptitude)
-        run: |
-          sudo apt install -y tar wget make cmake gcc g++ python3 openmpi-* python python-dev python3-dev python3-venv libopenmpi-dev
-          pip3 install pyyaml rich fypp
-
-      - name: Build & Test MFC (CPU)
+      - name: Post-Clone Setup
         run: |
           chmod +x ./mfc.sh
-          ./mfc.sh build -m release-cpu -j $(nproc)
-          ./mfc.sh test -j $(nproc)
+      
+      - name: Setup & Environment Variables
+        if:   matrix.os == 'macos-latest'
+        run: |
+          echo "HOMEBREW_CC=gcc-${{ matrix.gcc }}"  >> $GITHUB_ENV
+          echo "HOMEBREW_CXX=g++-${{ matrix.gcc }}" >> $GITHUB_ENV
+          echo "OMPI_MPICC=gcc-${{ matrix.gcc }}"   >> $GITHUB_ENV
+          echo "OMPI_CXX=g++-${{ matrix.gcc }}"     >> $GITHUB_ENV
+          echo "OMPI_FC=gfortran-${{ matrix.gcc }}" >> $GITHUB_ENV
+      
+      - name: Install Dependencies (via Aptitude)
+        if:   matrix.os == 'ubuntu-latest'
+        run: >-
+          sudo apt install -y tar wget make cmake gcc g++ python3 openmpi-*
+          python python-dev python3-dev python3-venv libopenmpi-dev
+
+      - name: Install Nvidia HPC SDK
+        if:   matrix.os == 'ubuntu-latest' && github.ref == 'refs/heads/GPU'
+        run: |
+          echo 'deb [trusted=yes] https://developer.download.nvidia.com/hpc-sdk/ubuntu/amd64 /' | sudo tee /etc/apt/sources.list.d/nvhpc.list
+          sudo apt-get update  -y
+          sudo apt-get install -y nvhpc-$(echo "${{ matrix.nvhpc }}" | tr '.' '-')
+          NVARCH=`uname -s`_`uname -m`
+          NVCOMPILERS="/opt/nvidia/hpc_sdk"
+          VERSION="${{ matrix.nvhpc }}"
+          CUDA_VERSION="${{ matrix.cuda }}"
+          echo "PATH=$NVCOMPILERS/$NVARCH/$VERSION/compilers/bin:$NVCOMPILERS/$NVARCH/$VERSION/comm_libs/mpi/bin:$PATH" >> $GITHUB_ENV
+          echo "CUDA_HOME=$NVCOMPILERS/$NVARCH/$VERSION/cuda/" >> $GITHUB_ENV
+          echo "CUDA_DIR=$NVCOMPILERS/$NVARCH/$VERSION/cuda/" >> $GITHUB_ENV
+          echo "LD_LIBRARY_PATH=$NVCOMPILERS/$NVARCH/$VERSION/cuda/$CUDA_VERSION/lib64:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+
+      - name: Install Dependencies (via Brew)
+        if: matrix.os == 'macos-latest'
+        run: |
+          brew install wget make python make cmake coreutils
+          brew install gcc@${{ matrix.gcc }}
+          brew install --build-from-source open-mpi
+
+      - name: Print MPI Configuration
+        run: |
+          mpif90 --version
+          mpif90 --showme
+          mpicc --version
+          mpicc --showme
+          mpicxx --version
+          mpicxx --showme
+
+      - name: Build MFC (CPU)
+        run:  ./mfc.sh build -m release-cpu -j $(nproc)
+          
+      - name: Test MFC (CPU)
+        run:  ./mfc.sh test -j $(nproc)
+
+      - name: Print MPI Configuration
+        run: |
+          mpif90 --version
+          mpif90 --showme
+          mpicc --version
+          mpicc --showme
+          mpicxx --version
+          mpicxx --showme
+
+      - name: Build MFC (GPU)
+        if:   github.ref == 'refs/heads/GPU'
+        run:  ./mfc.sh build -m release-gpu -j $(nproc)
 
       - name: Upload logs
         uses: actions/upload-artifact@v2
-        if: always()
+        if:   always()
         with:
-          name: Ubuntu-logs
+          name: ${{ matrix.os }}
           path: |
             build/**/*.log
             tests/**/*.dat

--- a/README.md
+++ b/README.md
@@ -95,28 +95,55 @@ To fetch, build, and run MFC and its dependencies on a UNIX-like system, you mus
 (GCC, NVHPC, etc., but *not Clang*), and an MPI wrapper (like Open MPI). 
 Below are some commands for popular operating systems and package managers.
 <p>
+
+[Anaconda](https://www.anaconda.com/) may interfere with the building process. If an issue arises, you can either uninstall the affected Anaconda packages, change the ordering of directory paths in your `$PATH`, or make aliases to the correct binaries.
  
-### \*nix
-
-* **Via [Aptitude](https://wiki.debian.org/Aptitude):**
-
-```console
-sudo apt install tar wget make cmake gcc g++ python3 "openmpi-*" python python-dev python3-dev python3-venv libopenmpi-dev
-```
-
-### MacOS (including x86 and M1/Apple Silicon)
-
-* **Via [Homebrew](https://brew.sh/):**
-
-You can modify the assignment on the first line to have the GCC major version you wish to have installed and use.
+### \*nix 
+ 
+- **Via [Aptitude](https://wiki.debian.org/Aptitude):**
 
 ```console
-USE_GCC_VERSION=11
-brew install wget make python make cmake gcc@$USE_GCC_VERSION
-HOMEBREW_CC=gcc-$USE_GCC_VERSION; HOMEBREW_CXX=g++-$USE_GCC_VERSION; brew install --build-from-source open-mpi
+$ sudo apt install tar wget make cmake gcc g++ python3 "openmpi-*" python python-dev python3-dev python3-venv libopenmpi-dev
+```
+ 
+If you wish to build MFC using [NVidia's NVHPC SDK](https://developer.nvidia.com/hpc-sdk), follow the instructions [here](https://developer.nvidia.com/nvidia-hpc-sdk-downloads).
+
+### MacOS (including x86 and M1/Apple Silicon) [**via [Homebrew](https://brew.sh/)**]
+ 
+ - **MacOS v10.15 (Catalina) or newer [ZSH]**
+
+```console
+$ touch ~/.zshrc
+$ open ~/.zshrc
 ```
 
-Further reading on `open-mpi` incompatibility with `clang`-based `gcc` on macOS: [here](https://stackoverflow.com/questions/27930481/how-to-build-openmpi-with-homebrew-and-gcc-4-9). We do *not* support `clang` due to conflicts with our Silo dependency. [Anaconda](https://www.anaconda.com/) may interfere with the building process if it has a higher priority than [Homebrew](https://brew.sh/) in your `$PATH`. If an issue arises, you can either uninstall the affected Anaconda packages, change the ordering of directory paths in your `$PATH`, or make aliases to the correct binaries.
+ - **Older than MacOS v10.15 (Catalina) [BASH]**
+ 
+```console
+$ touch ~/.bash_profile
+$ open ~/.bash_profile
+```
+ 
+An editor should open. Please paste the following lines into it. If you wish to use a version of GNU's GCC other than 11, modify the first assignment. These lines ensure that LLVM's Clang, and Apple's modified version of GCC, won't be used to compile MFC. Further reading on `open-mpi` incompatibility with `clang`-based `gcc` on macOS: [here](https://stackoverflow.com/questions/27930481/how-to-build-openmpi-with-homebrew-and-gcc-4-9). We do *not* support `clang` due to conflicts with our Silo dependency.
+
+```console
+# === MFC MPI Installation ===
+export MFC_GCC_VER=11
+export HOMEBREW_CC=gcc-$MFC_GCC_VER
+export HOMEBREW_CXX=g++-$MFC_GCC_VER
+export OMPI_MPICC=gcc-$MFC_GCC_VER
+export OMPI_CXX=g++-$MFC_GCC_VER
+export OMPI_FC=gfortran-$MFC_GCC_VER
+# === MFC MPI Installation ===
+```
+
+In your terminal, execute the commands bellow. They will download the dependencies MFC requires to build itself. `open-mpi` will be compiled from source, using the version of GCC we specified above with the environment variables `HOMEBREW_CC` and `HOMEBREW_CXX`. Building this package might take a while.
+ 
+```console
+$ reset
+$ brew install wget make python make cmake coreutils gcc@$MFC_GCC_VER
+$ brew install --build-from-source open-mpi
+```
 
 ### Fetch and build MFC
 
@@ -127,8 +154,8 @@ This should have no impact on your local installation(s) of these packages.
 + **Fetch MFC:**
 
 ```console
-git clone https://github.com/MFlowCode/MFC
-cd MFC
+$ git clone https://github.com/MFlowCode/MFC
+$ cd MFC
 ```
 
 + **(Optional) Configure MFC defaults in [mfc.user.yaml](mfc.user.yaml):**
@@ -138,7 +165,7 @@ If you wish, you can override MFC's default build parameters in [mfc.user.yaml](
 + **Build MFC and its dependencies with 8 threads in `release-cpu` mode:**
 
 ```console
-./mfc.sh build -j 8
+$ ./mfc.sh build -j 8
 ```
 
 To build MFC in different configurations (herein, *modes*), the `-m <mode>` option
@@ -152,7 +179,7 @@ you can use others such as `release-gpu`.
 + Run MFC's tests with as many concurrent processes as you wish to make sure it was correctly built and your environment is adequate
 
 ```console
-./mfc.sh test -j $(nproc)
+$ ./mfc.sh test -j $(nproc)
 ```
 
 Please refer to the [Testing](#testing-mfc) section of this document for more information. 
@@ -178,7 +205,7 @@ can also be found in [samples/3d_sphbubcollapse/](samples/3D_sphbubcollapse/).
 To run all stages of MFC, that is [pre_process](src/pre_process_code/), [simulation](src/simulation_code/), and [post_process](src/post_process_code/) on the sample case [2D_shockbubble](samples/2D_shockbubble/),
 
 ```console
-./mfc.sh run samples/2D_shockbubble/case.py
+$ ./mfc.sh run samples/2D_shockbubble/case.py
 ```
 
 If you want to run a subset of the available stages, you can use the `-t` argument.
@@ -191,14 +218,14 @@ For example,
 - Running [pre_process](src/pre_process_code/) with 2 cores:
 
 ```console
-./mfc.sh run samples/2D_shockbubble/case.py -t pre_process -n 2
+$ ./mfc.sh run samples/2D_shockbubble/case.py -t pre_process -n 2
 ```
 
 - Running [simulation](src/simulation_code/) and [post_process](src/post_process_code/)
 using 4 cores:
 
 ```console
-./mfc.sh run samples/2D_shockbubble/case.py -t simulation post_process -n 4
+$ ./mfc.sh run samples/2D_shockbubble/case.py -t simulation post_process -n 4
 ```
 
 Most parameters have sensible defaults which can be overridden in [mfc.user.yaml](mfc.user.yaml):
@@ -216,7 +243,7 @@ requires you to only specify one target with the `-t` option. The number of node
 respectively be specified with the `-N` (i.e `--nodes`) and `-g` (i.e `--gpus-per-node`) options.
 
 ```console
-./mfc.sh run samples/2D_shockbubble/case.py -e parallel -N 2 -n 4 -g 4 -t simulation
+$ ./mfc.sh run samples/2D_shockbubble/case.py -e parallel -N 2 -n 4 -g 4 -t simulation
 ```
 
 Other useful arguments include:
@@ -244,15 +271,15 @@ allocate resources. Therefore, the MFC constructs equivalent resource-sets in ta
 - Oak Ridge National Laboratory's [Summit](https://www.olcf.ornl.gov/summit/):
 
 ```console
-./mfc.sh run samples/2D_shockbubble/case.py -e parallel    \
-             -N 2 -n 4 -g 4​ -t simulation -a <redacted>
+$ ./mfc.sh run samples/2D_shockbubble/case.py -e parallel    \
+               -N 2 -n 4 -g 4​ -t simulation -a <redacted>
 ```
 
 - University of California, San Diego's [Expanse](https://www.sdsc.edu/services/hpc/expanse/):
 
 ```console
-./mfc.sh run samples/2D_shockbubble/case.py -e parallel -p GPU -t simulation​ \
-             -N 2 -n 8 -g 8​ -f="--gpus=v100-32:16" -b mpirun –w 00:30:00
+$ ./mfc.sh run samples/2D_shockbubble/case.py -e parallel -p GPU -t simulation​ \
+               -N 2 -n 8 -g 8​ -f="--gpus=v100-32:16" -b mpirun –w 00:30:00
 ```
 
 # Testing MFC
@@ -265,7 +292,7 @@ If you want to only run certain tests, you can pass the argument `-o` (i.e `--on
 
 An example of running targeted tests:
 ```console
-./mfc.sh test -j 8 -o 1A6B6EB3 0F5DB706
+$ ./mfc.sh test -j 8 -o 1A6B6EB3 0F5DB706
 ```
 
 # Development
@@ -283,7 +310,7 @@ You can inspect the generated `.f90` files located in `build/<mode name>/src/<na
 On computer systems that run using environment modules, with implementations like [TACC's Lmod](https://github.com/TACC/Lmod), MFC provides a script that can load modules that have been used by contributors.
 
 ```console
-. ./mfc.sh load
+$ . ./mfc.sh load
 ``` 
 
 The list of modules offered by a system is subject to change. The aforementioned script serves as a convenient way to load modules that should work for most users of MFC. 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ $ touch ~/.bash_profile
 $ open ~/.bash_profile
 ```
  
-An editor should open. Please paste the following lines into it. If you wish to use a version of GNU's GCC other than 11, modify the first assignment. These lines ensure that LLVM's Clang, and Apple's modified version of GCC, won't be used to compile MFC. Further reading on `open-mpi` incompatibility with `clang`-based `gcc` on macOS: [here](https://stackoverflow.com/questions/27930481/how-to-build-openmpi-with-homebrew-and-gcc-4-9). We do *not* support `clang` due to conflicts with our Silo dependency.
+An editor should open. Please paste the following lines into it before saving the file. If you wish to use a version of GNU's GCC other than 11, modify the first assignment. These lines ensure that LLVM's Clang, and Apple's modified version of GCC, won't be used to compile MFC. Further reading on `open-mpi` incompatibility with `clang`-based `gcc` on macOS: [here](https://stackoverflow.com/questions/27930481/how-to-build-openmpi-with-homebrew-and-gcc-4-9). We do *not* support `clang` due to conflicts with our Silo dependency.
 
 ```console
 # === MFC MPI Installation ===
@@ -137,13 +137,14 @@ export OMPI_FC=gfortran-$MFC_GCC_VER
 # === MFC MPI Installation ===
 ```
 
-In your terminal, execute the commands bellow. They will download the dependencies MFC requires to build itself. `open-mpi` will be compiled from source, using the version of GCC we specified above with the environment variables `HOMEBREW_CC` and `HOMEBREW_CXX`. Building this package might take a while.
- 
+Close your the open editor **and** terminal windows. Open a **new terminal** window before executing the commands bellow.
+
 ```console
-$ reset
 $ brew install wget make python make cmake coreutils gcc@$MFC_GCC_VER
 $ brew install --build-from-source open-mpi
 ```
+ 
+ They will download the dependencies MFC requires to build itself. `open-mpi` will be compiled from source, using the version of GCC we specified above with the environment variables `HOMEBREW_CC` and `HOMEBREW_CXX`. Building this package might take a while.
 
 ### Fetch and build MFC
 

--- a/bootstrap/mfc.dev.yaml
+++ b/bootstrap/mfc.dev.yaml
@@ -85,8 +85,12 @@ targets:
         hash: e8edaced12f139ddf16167987ded15e5da1b98da
     build:
       - mkdir -p build
-      - cd build && ${COMPILERS} cmake -DZFP_WITH_OPENMP=OFF BUILD_UTILITIES=OFF BUILD_ZFORP=ON -DZFP_WITH_CUDA=ON ..
-      - cd build && ${COMPILERS} cmake --build . --config Release
+      - >-
+        cd build && cmake -DZFP_WITH_OPENMP=OFF BUILD_UTILITIES=OFF
+        BUILD_ZFORP=ON -DZFP_WITH_CUDA=ON
+        -DCMAKE_C_COMPILER=nvc -DCMAKE_CXX_COMPILER=nvc++
+        -DCUDA_TOOLKIT_ROOT_DIR="${CUDA:INSTALL_PATH}" ..
+      - cd build && cmake --build . --config Release
       - rsync -avh --progress "$(pwd)/build/bin/" "${INSTALL_PATH}/bin"
       - rsync -avh --progress "$(pwd)/build/"lib*/ "${INSTALL_PATH}/lib"
     clean:

--- a/bootstrap/mfc.py
+++ b/bootstrap/mfc.py
@@ -51,11 +51,11 @@ class MFCState:
         def update_mode():
             if update_mode.triggered:
                 return
-            
+
             update_mode.triggered = True
 
             rich.print(f'[yellow]Switching to [bold green]{self.args["mode"]}[/bold green] from [bold magenta]{self.lock.mode}[/bold magenta]. Purging references to other modes...[/yellow]')
-            
+
             # Update mode in mfc.user.yaml
             self.lock.mode = self.args["mode"]
             self.lock.save()
@@ -68,7 +68,7 @@ class MFCState:
 
                 # Delete the build directory of other modes
                 common.delete_directory_recursive(self.build.get_mode_base_path(mode.name))
-        
+
         update_mode.triggered = False
 
         # User requested a new mode using -m as a command-line argument
@@ -81,7 +81,7 @@ class MFCState:
             # There exists a (built) target, which is not a common one, that has different mode
             if entry.target.common_mode == None and entry.metadata.mode != self.args["mode"]:
                 update_mode()
-                
+
                 # Remove it
                 del self.lock.targets[idx]
 

--- a/bootstrap/mfc.py
+++ b/bootstrap/mfc.py
@@ -12,7 +12,7 @@ import common
 import signal
 
 from run   import run
-from tests import test
+from tests import tests
 
 class MFCState:
     def __init__(self) -> None:
@@ -27,7 +27,7 @@ class MFCState:
         self.args  = args.parse(self)
         self.clean = clean.MFCClean(self)
         self.build = MFCBuild(self)
-        self.test  = test.MFCTest(self)
+        self.test  = tests.MFCTest(self)
         self.run   = run.MFCRun(self)
 
         self.check_mode()

--- a/bootstrap/tests/cases.py
+++ b/bootstrap/tests/cases.py
@@ -14,7 +14,7 @@ def get_dimensions():
         dimParams = {**dimInfo[1]}
 
         for dimCmp in dimInfo[0]:
-            dimParams.update({ f"{dimCmp}_domain%beg": 0.E+00, 
+            dimParams.update({ f"{dimCmp}_domain%beg": 0.E+00,
                                f"{dimCmp}_domain%end": 1.E+00 })
 
         for patchID in range(1, 3+1):
@@ -65,7 +65,7 @@ def get_dimensions():
                 dimParams[f"patch_icpp({patchID})%vel(3)"] = 0.0
 
         r.append((dimInfo, dimParams))
-    
+
     return r
 
 
@@ -85,7 +85,7 @@ def generate_cases() -> list:
 
             if bc != -3: # Use bc = 3 henceforth
                 stack.pop()
-        
+
         for weno_order in [3, 5]:
             stack.push(f"weno_order={weno_order}", {'weno_order': weno_order})
 
@@ -97,9 +97,9 @@ def generate_cases() -> list:
 
                 if not (mp_weno == 'T' and weno_order != 5):
                     cases.append(create_case(stack, '', {}))
-                
+
                 stack.pop()
-            
+
             stack.pop()
 
         for num_fluids in [1, 2]:
@@ -139,7 +139,7 @@ def generate_cases() -> list:
         else:
             cases.append(create_case(stack, f'ppn=2', {'ppn': 2}))
 
-        stack.push('', {'dt': [1e-07, 1e-06, 1e-06][len(dimInfo[0])-1]}) 
+        stack.push('', {'dt': [1e-07, 1e-06, 1e-06][len(dimInfo[0])-1]})
 
         if len(dimInfo[0]) > 0:
             stack.push(f"bubbles={'T'}", {"bubbles": 'T'})
@@ -147,9 +147,9 @@ def generate_cases() -> list:
             stack.push(f'', {
                 'nb' : 3, 'fluid_pp(1)%gamma' : 0.16, 'fluid_pp(1)%pi_inf': 3515.0,
                 'fluid_pp(2)%gamma': 2.5, 'fluid_pp(2)%pi_inf': 0.0, 'fluid_pp(1)%mul0' : 0.001002,
-                'fluid_pp(1)%ss' : 0.07275,'fluid_pp(1)%pv' : 2338.8,'fluid_pp(1)%gamma_v' : 1.33, 
+                'fluid_pp(1)%ss' : 0.07275,'fluid_pp(1)%pv' : 2338.8,'fluid_pp(1)%gamma_v' : 1.33,
                 'fluid_pp(1)%M_v' : 18.02,'fluid_pp(1)%mu_v' : 8.816e-06,'fluid_pp(1)%k_v' : 0.019426,
-                'fluid_pp(2)%gamma_v' : 1.4,'fluid_pp(2)%M_v' : 28.97,'fluid_pp(2)%mu_v' : 1.8e-05, 
+                'fluid_pp(2)%gamma_v' : 1.4,'fluid_pp(2)%M_v' : 28.97,'fluid_pp(2)%mu_v' : 1.8e-05,
                 'fluid_pp(2)%k_v' : 0.02556, 'patch_icpp(1)%alpha_rho(1)': 0.999999999999, 'patch_icpp(1)%alpha(1)':
                 1e-12, 'patch_icpp(2)%alpha_rho(1)': 0.96, 'patch_icpp(2)%alpha(1)': 4e-02,  'patch_icpp(3)%alpha_rho(1)': 0.999999999999,
                 'patch_icpp(3)%alpha(1)': 1e-12, 'patch_icpp(1)%pres': 1.0, 'patch_icpp(2)%pres': 1.0,
@@ -166,7 +166,7 @@ def generate_cases() -> list:
 
             for polytropic in ['T', 'F']:
                 stack.push(f"polytropic={polytropic}", {'polytropic' : polytropic})
-                
+
                 for bubble_model in [3, 2]:
                     stack.push(f"bubble_model={bubble_model}", {'bubble_model' : bubble_model})
 
@@ -174,7 +174,7 @@ def generate_cases() -> list:
                         cases.append(create_case(stack, '', {}))
 
                     stack.pop()
-                
+
                 stack.pop()
 
             stack.push('', {'polytropic': 'T', 'bubble_model': 2})
@@ -214,7 +214,7 @@ def generate_cases() -> list:
 
 def generate_filtered_cases(args: dict):
     cases: list = generate_cases()
-    
+
     if len(args["only"]) > 0:
         for i, case in enumerate(cases[:]):
             case: Case
@@ -227,5 +227,5 @@ def generate_filtered_cases(args: dict):
 
             if not doKeep:
                 cases.remove(case)
-    
+
     return cases

--- a/bootstrap/tests/pack.py
+++ b/bootstrap/tests/pack.py
@@ -1,4 +1,3 @@
-from itertools import accumulate
 import re
 import math
 import dataclasses
@@ -18,7 +17,7 @@ class Error:
     relative: float
 
     def __repr__(self) -> str:        
-        return f"abs: {self.absolute:.2E}, rel: {self.relative*100:.2E}%"
+        return f"abs: {self.absolute:.2E}, rel: {self.relative:.2E}"
 
 
 def compute_error(measured: float, expected: float) -> Error:
@@ -43,11 +42,16 @@ class AverageError:
         self.count       = 0
 
     def get(self) -> Error:
+        if self.count == 0:
+            return Error(0, 0)
+
         return Error(self.accumulated.absolute / self.count,
                      self.accumulated.relative / self.count)
 
     def push(self, error: Error) -> None:
-        if math.isnan(self.accumulated.relative):
+        # Do not include nans in the result
+        # See: compute_error()
+        if math.isnan(error.relative):
             return
         
         self.accumulated.absolute += error.absolute

--- a/bootstrap/tests/pack.py
+++ b/bootstrap/tests/pack.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 
 import common
-import tests.test as test
+import tests.tests as tests
 
 from common import MFCException
 
@@ -93,7 +93,7 @@ def load(filepath: str) -> Pack:
     return Pack(entries)
 
 
-def generate(case: test.Case) -> Pack:
+def generate(case: tests.Case) -> Pack:
     entries = []
 
     case_dir = case.get_dirpath()
@@ -110,6 +110,10 @@ def generate(case: test.Case) -> Pack:
         numbers_str = re.sub(pattern, " ", data_content.replace('\n', '')).strip()
         
         doubles: list = [ float(e) for e in numbers_str.split(' ') ] 
+
+        for double in doubles:
+            if math.isnan(double):
+                raise MFCException(f"A NaN was found while generating a pack file for {case.get_uuid()}.")
 
         entries.append(PackEntry(short_filepath,doubles))
 
@@ -160,6 +164,12 @@ def check_tolerance(uuid: str, candidate: Pack, golden: Pack, tol: float) -> Err
             # Keep track of the error and average errors
             error = compute_error(cVal, gVal)
             avg_err.push(error)
+
+            if math.isnan(gVal):
+                raise MFCException(f"A NaN was found in the golden file for {uuid}.")
+
+            if math.isnan(cVal):
+                raise MFCException(f"A NaN was found in the pack file for {uuid}.")
 
             if not is_close(error, Tolerance(absolute=tol, relative=tol)):
                 raise MFCException(f"""\

--- a/bootstrap/tests/tests.py
+++ b/bootstrap/tests/tests.py
@@ -46,9 +46,9 @@ class MFCTest:
     def handle_case(self, test: Case):
         test.create_directory()
 
-        if 'qbmm' in test.params:
+        if test.params.get('qbmm', 'F') == 'T':
             tol = 1e-7
-        elif 'bubbles' in test.params:
+        elif test.params.get('bubbles', 'F') == 'T':
             tol = 1e-10
         else:
             tol = 1e-12

--- a/bootstrap/tests/tests.py
+++ b/bootstrap/tests/tests.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import os
-import signal
 
 
 import common
@@ -73,5 +72,5 @@ class MFCTest:
         if not os.path.isfile(golden_filepath):
             raise MFCException(f"tests/{test.get_uuid()}: Golden file doesn't exist! To generate golden files, use the '-g' flag.")
 
-        error = tests.pack.check_tolerance(test.get_uuid(), pack, tests.pack.load(golden_filepath), tol)
+        error = tests.pack.check_tolerance(test, pack, tests.pack.load(golden_filepath), tol)
         rich.print(f" |->  [bold magenta]{test.get_uuid()}[/bold magenta]  | {error.relative:+0.1E} | {tol:+0.1E} | {test.trace})")

--- a/bootstrap/tests/tests.py
+++ b/bootstrap/tests/tests.py
@@ -36,7 +36,7 @@ class MFCTest:
             self.mfc.build.build_target(f"mfc", "> > ")
 
         # Run cases with multiple threads (if available)
-        rich.print(f" |-+------------+----------+----------+---------+")         
+        rich.print(f" |-+------------+----------+----------+---------+")
         rich.print(f" | | tests/[bold magenta]UUID[/bold magenta] | Error RE |   Tol.   | Summary |")
         rich.print(f" |-+------------+----------+----------+---------+")
         self.sched.run(generate_filtered_cases(self.mfc.args), self.handle_case)

--- a/bootstrap/tests/tests.py
+++ b/bootstrap/tests/tests.py
@@ -37,9 +37,9 @@ class MFCTest:
             self.mfc.build.build_target(f"mfc", "> > ")
 
         # Run cases with multiple threads (if available)
-        rich.print(f" |-+------------+----------+----------+--------")
-        rich.print(f" | | tests/[bold magenta]UUID[/bold magenta] | Error RE |  % Tol.  | Summary")
-        rich.print(f" |-+------------+----------+----------+--------")
+        rich.print(f" |-+------------+----------+----------+---------+")         
+        rich.print(f" | | tests/[bold magenta]UUID[/bold magenta] | Error RE |   Tol.   | Summary |")
+        rich.print(f" |-+------------+----------+----------+---------+")
         self.sched.run(generate_filtered_cases(self.mfc.args), self.handle_case)
 
         rich.print(f"> Tested [bold green]✓[/bold green]")
@@ -74,4 +74,4 @@ class MFCTest:
             raise MFCException(f"tests/{test.get_uuid()}: Golden file doesn't exist! To generate golden files, use the '-g' flag.")
 
         error = tests.pack.check_tolerance(test.get_uuid(), pack, tests.pack.load(golden_filepath), tol)
-        rich.print(f" |->  [bold magenta]{test.get_uuid()}[/bold magenta]  | {error.relative:+0.1E} | {(error.relative/tol)*100:+0.1E} | {test.trace})")
+        rich.print(f" |->  [bold magenta]{test.get_uuid()}[/bold magenta]  | {error.relative:+0.1E} | {tol:+0.1E} | {test.trace})")

--- a/bootstrap/tests/threads.py
+++ b/bootstrap/tests/threads.py
@@ -35,7 +35,7 @@ class MFCTestThreadManager:
         self.threads    = []
         self.nThreads   = nThreads
         self.nAvailable = self.nThreads
-    
+
     def join_first_dead_thread(self, progress, complete_tracker) -> None:
         for threadID, threadHolder in enumerate(self.threads):
             threadHolder: TestThreadHolder
@@ -48,7 +48,7 @@ class MFCTestThreadManager:
                 progress.advance(complete_tracker)
 
                 del self.threads[threadID]
-                
+
                 break
 
     def run(self, cases: list, handle_case) -> None:
@@ -71,13 +71,13 @@ class MFCTestThreadManager:
 
                     # Keep track of threads that are done
                     self.join_first_dead_thread(progress, complete_tracker)
-                    
+
                     # Do not overwhelm this core with this loop
                     time.sleep(0.05)
 
                 # Launch Thread
                 progress.advance(queue_tracker)
-                
+
                 thread = TestThread(target=handle_case, args=(test,))
                 thread.start()
 
@@ -88,6 +88,6 @@ class MFCTestThreadManager:
             while len(self.threads) != 0:
                 # Keep track of threads that are done
                 self.join_first_dead_thread(progress, complete_tracker)
-            
+
                 # Do not overwhelm this core with this loop
                 time.sleep(0.05)


### PR DESCRIPTION
This pull request includes:
- A (re)integrated check for NaNs
- macOS Continuous Integration (CPUs only)
- CI on GitHub, for `master` and `GPU`, on Ubuntu and macOS, are now part of the same job description, using the Matrix strategy, lessening code duplication.
- Removal of GPU tests on Ubuntu CI (replaced by Ascent CI). The Ubuntu CI didn't use GPUs anyway. We still build MFC in `release-gpu` mode during Ubuntu CI, with NVHPC.
- Fix a visual bug during testing that displayed the average relative error of a test as being `NaN`.
- Tolerance is now displayed in the same format as the relative error (not as a %).
- Update @anandrdbz's tolerance settings after refactor- ZFP: Force the use of `nvc` and `nvc++` (the only compatible NVHPC compilers when building with Cuda support).
  Related to #78.
- A more thorough and comprehensive fix for macOS build issues (detailed in the README).
- A traceback is now printed when a test fails (i.e the test's description), as well as the tolerance.