### PR TITLE
Fixes to mfc.sh run & Updated load.sh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,13 +6,14 @@ on:
     paths:
       - '**.f90'
       - '**.fpp'
-      - '**.sh'
+      - 'mfc.sh'
       - '**.py'
       - '**.yaml'
       - '**.yml'
       - 'golden.txt'
       - 'Makefile'
       - 'makefile'
+      - 'CMakeLists.txt'
 
   pull_request:
     branches: [ master, GPU ]

--- a/bootstrap/args.py
+++ b/bootstrap/args.py
@@ -45,14 +45,16 @@ def parse(mfc):
 
     clean.add_argument("-r", "--recursive", default=False, action="store_true", help="Clean specified targets and their dependencies recursively.")
 
+    binaries = [ b.bin  for b in BINARIES ]
+
     # === TEST ===
     add_common_arguments(test)
     test.add_argument("-g", "--generate", action="store_true", help="Generate golden files.")
     test.add_argument("-o", "--only",     nargs="+", type=str, default=[], metavar="L", help="Only run tests with ids or hashes L.")
+    test.add_argument("-b", "--binary",   choices=binaries, type=str, default=None, help="(Serial) Override MPI execution binary")
 
     # === RUN ===
     engines  = [ e.slug for e in ENGINES  ]
-    binaries = [ b.bin  for b in BINARIES ]
 
     add_common_arguments(run)
     run.add_argument("input",                  metavar="INPUT",                 type=str,                                      help="Input file for run.")

--- a/bootstrap/load.sh
+++ b/bootstrap/load.sh
@@ -116,7 +116,7 @@ elif [ "$u_computer" == "b" ]; then # Bridges2
     COMPUTER="$BRIDGES2"
 
     if [ "$u_cg" == "c" ]; then
-        MODULES=("gcc/10.2.0")
+        MODULES=("intel/2021.3.0" "intelmpi/2021.3.0-intel2021.3.0")
     elif [ "$u_cg" == "g" ]; then
         MODULES=("nvhpc/22.1" "cuda/11.1.1")
     fi
@@ -157,7 +157,7 @@ elif [ "$u_computer" == "e" ]; then # Expanse
     COMPUTER="$EXPANSE"
 
     if [ "$u_cg" == "c" ]; then
-        MODULES=("cpu/0.15.4" "gcc/10.2.0" "openmpi/gcc/64/1.10.7")
+        MODULES=("cpu/0.15.4" "intel/19.1.1.217" "intel-mpi/2019.8.254")
     elif [ "$u_cg" == "g" ]; then
         MODULES=("gpu/0.15.4" "openmpi/4.0.5" "cuda/11.0.2" "nvhpc/22.2")
     fi
@@ -167,10 +167,7 @@ elif [ "$u_computer" == "p" ]; then # Phoenix
     COMPUTER="$PHOENIX"
 
     if [ "$u_cg" == "c" ]; then
-        echo -e $RED"Error: CPU not supported on Phoenix."$COLOR_RESET
-        
-        on_error
-        return
+        MODULES=("intel/19.0.5" "mvapich2/2.3.2")
     elif [ "$u_cg" == "g" ]; then
         MODULES=("cuda/11.2" "nvhpc/22.1")
     fi

--- a/bootstrap/run/engines.py
+++ b/bootstrap/run/engines.py
@@ -165,8 +165,6 @@ printf "$TABLE_FORMAT_LINE" "Total-time:"  "$(expr $t_stop - $t_start)s"  "Exit 
 printf "$TABLE_FORMAT_LINE" "End-time:"    "$(date +%T)"                  "End-date:"  "$(date +%T)"
 printf "$TABLE_FOOTER"
 
-printf "\\nI'll see you on the dark side of the moon...\\n\\n"
-
 exit $code
 """
 
@@ -224,7 +222,13 @@ exit $code
                 s = s.replace(match, repl)
             else:
                 # If not specified, then remove the line it appears on
-                s = re.sub(f"^.*\{match}.*$\n", "", s, flags=re.MULTILINE)
+                REG_PATTERN = f"^.*\{match}.*$\n"
+                lines = re.findall(REG_PATTERN, s, flags=re.MULTILINE)
+                s = re.sub(REG_PATTERN, "", s, flags=re.MULTILINE)
+
+                rich.print(f"""
+[bold yellow]Warning:[/bold yellow] [magenta]{match[1:-1]}[/magenta] was not specified. Thus, the following lines will be discarded:
+{chr(10).join([ f' - {line.strip()}' for line in lines ])}""")
 
         return s
 

--- a/bootstrap/run/engines.py
+++ b/bootstrap/run/engines.py
@@ -187,7 +187,7 @@ exit $code
                 return None
 
         # It may me a calculation. Try and parse it
-        for var_candidate in re.split(r"[\*,\+,\-,\/,\(,\),\,]", expr):
+        for var_candidate in re.split(r"[\*,\ ,\+,\-,\/,\\,\%,\,,\.,\^,\',\",\[,\],\(,\),\=]", expr):
             evaluated = self.evaluate_variable(var_candidate)
 
             if evaluated is not None and not common.isspace(evaluated):                
@@ -222,13 +222,9 @@ exit $code
                 s = s.replace(match, repl)
             else:
                 # If not specified, then remove the line it appears on
-                REG_PATTERN = f"^.*\{match}.*$\n"
-                lines = re.findall(REG_PATTERN, s, flags=re.MULTILINE)
-                s = re.sub(REG_PATTERN, "", s, flags=re.MULTILINE)
+                s = re.sub(f"^.*\{match}.*$\n", "", s, flags=re.MULTILINE)
 
-                rich.print(f"""
-[bold yellow]Warning:[/bold yellow] [magenta]{match[1:-1]}[/magenta] was not specified. Thus, the following lines will be discarded:
-{chr(10).join([ f' - {line.strip()}' for line in lines ])}""")
+                rich.print(f"[bold yellow]Warning:[/bold yellow] [magenta]{match[1:-1]}[/magenta] was not specified. Thus, any line it figures on will be discarded.")
 
         return s
 
@@ -246,7 +242,7 @@ exit $code
 
 ENGINES = [ SerialEngine(), ParallelEngine() ]
 
-def get_engine(slug: str) -> Engine:
+def get_engine(slug: str) -> Engine:    
     engine: Engine = None
     for candidate in ENGINES:
         candidate: Engine

--- a/bootstrap/run/queues.py
+++ b/bootstrap/run/queues.py
@@ -56,8 +56,6 @@ class SLURMSystem(QueueSystem):
 QUEUE_SYSTEMS = [ LSFSystem(), SLURMSystem(), PBSSystem() ]
 
 def get_system() -> QueueSystem:    
-    return SLURMSystem()
-
     for system in QUEUE_SYSTEMS:
         if system.is_active():
             return system

--- a/bootstrap/tests/case.py
+++ b/bootstrap/tests/case.py
@@ -111,9 +111,13 @@ class Case:
         self.params = {**BASE_CFG.copy(), **mods}
 
     def run(self, args: dict) -> subprocess.CompletedProcess:
+        binary_option = ""
+        if args["binary"] is not None:
+            binary_option = f"-b {args['binary']}"
+
         command: str = f'''\
 ./mfc.sh run "{self.get_dirpath()}/case.py" -m "{args["mode"]}" -n {self["ppn"]} \
--t pre_process simulation 2>&1\
+-t pre_process simulation {binary_option} 2>&1\
 '''
 
         return subprocess.run(command, stdout=subprocess.PIPE,
@@ -175,7 +179,7 @@ class CaseGeneratorStack:
     def push(self, trace: str, mods: dict) -> None:
         self.trace.append(trace)
         self.mods.append(mods)
-    
+
     def pop(self) -> None:
         return (self.mods.pop(), self.trace.pop())
 

--- a/bootstrap/tests/tests.py
+++ b/bootstrap/tests/tests.py
@@ -58,7 +58,7 @@ class MFCTest:
         common.file_write(f"{test.get_dirpath()}/out.txt", cmd.stdout)
 
         if cmd.returncode != 0:
-            raise MFCException(f"tests/{test.get_uuid()}: Failed to execute MFC.")
+            raise MFCException(f"tests/{test.get_uuid()}: Failed to execute MFC [{test.trace}]")
 
         pack = tests.pack.generate(test)
         pack.save(f"{test.get_dirpath()}/pack.txt")
@@ -70,7 +70,7 @@ class MFCTest:
             pack.save(golden_filepath)
 
         if not os.path.isfile(golden_filepath):
-            raise MFCException(f"tests/{test.get_uuid()}: Golden file doesn't exist! To generate golden files, use the '-g' flag.")
+            raise MFCException(f"tests/{test.get_uuid()}: Golden file doesn't exist! To generate golden files, use the '-g' flag. [{test.trace}]")
 
         error = tests.pack.check_tolerance(test, pack, tests.pack.load(golden_filepath), tol)
         rich.print(f" |->  [bold magenta]{test.get_uuid()}[/bold magenta]  | {error.relative:+0.1E} | {tol:+0.1E} | {test.trace})")

--- a/templates/lsf.sh
+++ b/templates/lsf.sh
@@ -31,12 +31,17 @@
 #BSUB -N
 #BSUB -P {account}
 #BSUB -W {"walltime"[:-3]}
+#>
+#> Note: The above expression for the walltime converts
+#>       the expression "hh:mm:ss" to the appropriate
+#>       format for the batch system ("hh:mm"). It is
+#>       a python expression evaluated at runtime.
+#>
+#>
 #> Note: The following options aren't enabled by default.
 #>       They serve as a guide to users that wish to pass
 #>       more options to the batch system.
 #>
-#> 
-#> 
 
 
 
@@ -60,7 +65,7 @@
 #>       the path the MFC executable.
 #>
 jsrun --smpiargs="-gpu"                      \
-      --nrs          {cpus_per_node}         \
+      --nrs          {cpus_per_node*nodes}   \
       --cpu_per_rs   1                       \
       --gpu_per_rs   {min(gpus_per_node, 1)} \
       --tasks_per_rs 1                       \

--- a/templates/pbs.sh
+++ b/templates/pbs.sh
@@ -60,9 +60,10 @@
 #>       on your system - if at all. {MFC::BIN} refers to
 #>       the path the MFC executable.
 #>
-srun --ntasks-per-node {cpus_per_node} \
-     -p "{partition}"                  \
+srun --ntasks-per-node {cpus_per_node}
      "{MFC::BIN}"
+#> mpirun -np {cpus_per_node*nodes} \
+#>        "{MFC::BIN}"
 
 {MFC::EPILOGUE}
 #>

--- a/templates/pbs.sh
+++ b/templates/pbs.sh
@@ -32,12 +32,12 @@
 #PBS -l walltime={walltime}
 #PBS -q {partition}
 #PBS -M {email}
+#>
 #> Note: The following options aren't enabled by default.
 #>       They serve as a guide to users that wish to pass
 #>       more options to the batch system.
 #>
-#> 
-#> 
+
 
 
 
@@ -60,10 +60,18 @@
 #>       on your system - if at all. {MFC::BIN} refers to
 #>       the path the MFC executable.
 #>
-srun --ntasks-per-node {cpus_per_node}
+srun                                   \ 
+     --nodes={nodes}                   \
+     --ntasks-per-node {cpus_per_node} \
      "{MFC::BIN}"
-#> mpirun -np {cpus_per_node*nodes} \
+#>
+#> srun --mpi=pmix   \
+#>      "{MFC::BIN}"
+#>
+#> mpirun                           \
+#>        -np {cpus_per_node*nodes} \
 #>        "{MFC::BIN}"
+#>
 
 {MFC::EPILOGUE}
 #>

--- a/templates/slurm.sh
+++ b/templates/slurm.sh
@@ -67,8 +67,9 @@
 #>       the path the MFC executable.
 #>
 srun --ntasks-per-node {cpus_per_node} \
-     -p "{partition}"                  \
      "{MFC::BIN}"
+#> mpirun -np {cpus_per_node*nodes} \
+#>        "{MFC::BIN}"
 
 {MFC::EPILOGUE}
 #>

--- a/templates/slurm.sh
+++ b/templates/slurm.sh
@@ -38,13 +38,14 @@
 #SBATCH --mail-user="{email}"
 #SBATCH --export=ALL
 #SBATCH --mail-type="BEGIN, END, FAIL"
+#>
 #> Note: The following options aren't enabled by default.
 #>       They serve as a guide to users that wish to pass
 #>       more options to the batch system.
 #>
 #> #SBATCH --mem=...
 #> #SBATCH --gpus=v100-16:{gpus_per_node*nodes}
-
+#>
 
 
 #> 
@@ -66,10 +67,18 @@
 #>       on your system - if at all. {MFC::BIN} refers to
 #>       the path the MFC executable.
 #>
-srun --ntasks-per-node {cpus_per_node} \
+srun                                   \
+     --nodes={nodes}                   \
+     --ntasks-per-node {cpus_per_node} \
      "{MFC::BIN}"
-#> mpirun -np {cpus_per_node*nodes} \
+#>
+#> srun --mpi=pmix   \
+#>      "{MFC::BIN}"
+#>
+#> mpirun                           \
+#>        -np {cpus_per_node*nodes} \
 #>        "{MFC::BIN}"
+#>
 
 {MFC::EPILOGUE}
 #>


### PR DESCRIPTION
This pull request includes:
- \+ Preemptive error messages in `mfc.sh run` for common situations
- \+ Detailed error messages
- \+ Warnings when lines get deleted in the batch files
- Verification that `release-cpu` mode runs in batch mode with two nodes on:
  - Summit
  - Expanse
  - Bridges2
  - Phoenix
  - Richardson
- \+ Modules were updated in `bootstrap/load.sh` where necessary.
- `mfc.sh test` now accepts the `-b` option to specify which MPI executable to use (serially)
- The addition of a few sample MPI commands in the templates.
- Removed a debug statement to force `SLURM`.
- Expanded regex to find variables referenced in `{expression}` statements: `[\*,\ ,\+,\-,\/,\\,\%,\,,\.,\^,\',\",\[,\],\(,\),\=]`.
- A few other miscellaneous fixes